### PR TITLE
Fix package name in plugin registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 2. Add to tailwind.config.js
 
 		plugins: [
-			require('tailwindcss-children'),
+			require('tailwind-children'),
 			]
 3. Build tailwind:
 		npx tailwindcss -i ./src/input.css -o ./dist/output.css


### PR DESCRIPTION
After copying plugin registration from the Readme, I was getting an error because the package name in the example (`tailwindcss-children`) doesn't  didn't match the actual package name, `tailwind-children`.

Including this, in case it helps anyone googling the error:

```
Error: Cannot find module 'tailwindcss-children'
[...]
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/path/to/tailwind.config.js',
    '/path/to/node_modules/tailwindcss/lib/cli.js'
  ]
```